### PR TITLE
Fix hardcoded tokenizer for llama.cpp models

### DIFF
--- a/src/lmql/models/model.py
+++ b/src/lmql/models/model.py
@@ -44,7 +44,7 @@ def inprocess(model_name, use_existing_configuration=False, **kwargs):
     # special case for 'llama.cpp'
     if model_name.startswith("llama.cpp:"):
         # kwargs["async_transport"] = True
-        kwargs["tokenizer"] = "huggyllama/llama-7b"
+        kwargs["tokenizer"] = kwargs.get("tokenizer", "huggyllama/llama-7b")
 
     if "endpoint" in kwargs:
         print("info: 'endpoint' argument is ignored for inprocess=True/local: models.")


### PR DESCRIPTION
When running LMQL with llama.cpp and OpenLlama 7B, the wrong tokenizer (huggyllama/llama-7b) gets loaded. Specifying a tokenizer by using `lmql.model("llama.cpp:...", tokenizer="danielhanchen/open_llama_3b")` doesn't solve that problem, because the tokenizer is hardcoded for llama.cpp models.

This PR allows specifying a tokenizer for llama.cpp models, fixing https://github.com/eth-sri/lmql/issues/154.